### PR TITLE
default alternative

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -187,10 +187,7 @@ module Split
 
     def start_trial(trial)
       experiment = trial.experiment
-      if override_present?(experiment.name) and experiment[override_alternative(experiment.name)]
-        ret = override_alternative(experiment.name)
-        ab_user[experiment.key] = ret if Split.configuration.store_override
-      elsif experiment.has_winner?
+      if experiment.has_winner?
         ret = experiment.winner.name
       else
         clean_old_versions(experiment)
@@ -199,6 +196,11 @@ module Split
         else
           if ab_user[experiment.key]
             ret = ab_user[experiment.key]
+          elsif override_present?(experiment.name) and experiment[override_alternative(experiment.name)]
+            trial.alternative = override_alternative(experiment.name)
+            trial.record!
+            call_trial_choose_hook(trial)
+            ret = begin_experiment(experiment, trial.alternative.name)
           else
             trial.choose!
             call_trial_choose_hook(trial)


### PR DESCRIPTION
leaves override functionality untouched (best use case: development). 
allow for default alternative - used to "pre-select" buckets/alternatives for users. 
