### PR TITLE
ruby 2.4 bigdecimal fixes

### DIFF
--- a/lib/split/dashboard/helpers.rb
+++ b/lib/split/dashboard/helpers.rb
@@ -19,7 +19,7 @@ module Split
     def round(number, precision = 2)
       BigDecimal(number.to_s).round(precision).to_f
     rescue ArgumentError
-      number
+      number.to_f
     end
 
     def confidence_level(z_score)

--- a/lib/split/dashboard/helpers.rb
+++ b/lib/split/dashboard/helpers.rb
@@ -17,7 +17,9 @@ module Split
     end
 
     def round(number, precision = 2)
-      BigDecimal.new(number.to_s).round(precision).to_f
+      BigDecimal(number.to_s).round(precision).to_f
+    rescue ArgumentError
+      number
     end
 
     def confidence_level(z_score)


### PR DESCRIPTION
we'll need to update this on ProductsSite, but there's a display bug right now on the Split dashboard that's causing it to error out. luckily this is just a visual bug, split's fine.

Lots of places in Split will return `"N/A"` if a value isn't present. Previously `BigDecimal()` would just swallow it, but as of Ruby 2.4 it seems that behavior has changed.